### PR TITLE
chore:add support for custom path at start

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Daniel Amenou
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Type: Array<string | RegExp> | string | RegExp<br />
 Default: null<br />
 Description: exclude files from load by the loader
 
+### customPath
+Type: string<br />
+Default: "."<br />
+Description: Change custom path for starting of reference to CSS file, useful for nested component structure
+
 
 ## Global Styles
 In some cases, we will want to create global class names (without hash)

--- a/src/index.js
+++ b/src/index.js
@@ -25,10 +25,10 @@ const defaultLoaders = [
   },
 ]
 
-const replaceMagicPath = (fileContent) => fileContent.replace(MAGIC_PATH_REGEX, ".")
+const replaceMagicPath = (fileContent, customPath = ".") => fileContent.replace(MAGIC_PATH_REGEX, customPath)
 
 const libStylePlugin = (options = {}) => {
-  const {loaders, include, exclude, importCSS = true, ...postCssOptions} = options
+  const {customPath, loaders, include, exclude, importCSS = true, ...postCssOptions} = options
   const allLoaders = [...(loaders || []), ...defaultLoaders]
   const filter = createFilter(include, exclude)
   const getLoader = (filepath) => allLoaders.find((loader) => loader.regex.test(filepath))
@@ -88,7 +88,7 @@ const libStylePlugin = (options = {}) => {
           fs
             .readFile(currentPath)
             .then((buffer) => buffer.toString())
-            .then(replaceMagicPath)
+            .then((fileContent) => replaceMagicPath(fileContent, customPath))
             .then((fileContent) => fs.writeFile(currentPath, fileContent))
         )
       )


### PR DESCRIPTION
1. Add MIT license
2. Custom path for nested path handling (had to add `../..` instead of just `.` to correctly reference path in nested structure