### PR TITLE
add customCSSPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ Type: string<br />
 Default: "."<br />
 Description: Change custom path for starting of reference to CSS file, useful for nested component structure
 
+### customCSSPath
+Type: (id: string) => string<br />
+Default: undefined<br />
+Description: A callback that allows you to transform where to store import the generated CSS file from. For example, `Header.module.scss` transformed to `Header.module.css`, but NextJS treat `.module.scss` as CSS module, so you cannot import it directly. Then you can use `return id.replace(process.cwd(), "").replace(/\\/g, "/").replace('.module', '')` to fix it. This will affect both CSS filename and the `import` statement.
+
 
 ## Global Styles
 In some cases, we will want to create global class names (without hash)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import {createFilter} from "rollup-pluginutils"
+import { createFilter } from "rollup-pluginutils"
 import postCssTransformer from "./postCssTransformer"
 import fs from "fs-extra"
 import sass from "sass"
@@ -16,19 +16,19 @@ const defaultLoaders = [
   {
     name: "sass",
     regex: /\.(sass|scss)$/,
-    process: ({filePath}) => ({code: sass.compile(filePath).css.toString()}),
+    process: ({ filePath }) => ({ code: sass.compile(filePath).css.toString() }),
   },
   {
     name: "css",
     regex: /\.(css)$/,
-    process: ({code}) => ({code}),
+    process: ({ code }) => ({ code }),
   },
 ]
 
 const replaceMagicPath = (fileContent, customPath = ".") => fileContent.replace(MAGIC_PATH_REGEX, customPath)
 
 const libStylePlugin = (options = {}) => {
-  const {customPath, loaders, include, exclude, importCSS = true, ...postCssOptions} = options
+  const { customPath, customCSSPath, loaders, include, exclude, importCSS = true, ...postCssOptions } = options
   const allLoaders = [...(loaders || []), ...defaultLoaders]
   const filter = createFilter(include, exclude)
   const getLoader = (filepath) => allLoaders.find((loader) => loader.regex.test(filepath))
@@ -47,13 +47,17 @@ const libStylePlugin = (options = {}) => {
 
       modulesIds.add(id)
 
-      const rawCss = await loader.process({filePath: id, code})
+      const rawCss = await loader.process({ filePath: id, code })
 
-      const postCssResult = await postCssTransformer({code: rawCss.code, fiePath: id, options: postCssOptions})
+      const postCssResult = await postCssTransformer({ code: rawCss.code, fiePath: id, options: postCssOptions })
 
       for (const dependency of postCssResult.dependencies) this.addWatchFile(dependency)
 
-      const cssFilePath = id.replace(process.cwd(), "").replace(/\\/g, "/")
+      const getFilePath = () => {
+        return id.replace(process.cwd(), "").replace(/\\/g, "/")
+      }
+
+      const cssFilePath = customCSSPath ? customCSSPath(id) : getFilePath()
 
       // create a new css file with the generated hash class names
       this.emitFile({
@@ -67,7 +71,7 @@ const libStylePlugin = (options = {}) => {
       // create a new js file with css module
       return {
         code: importStr + postCssResult.code,
-        map: {mappings: ""},
+        map: { mappings: "" },
       }
     },
 
@@ -101,4 +105,4 @@ const onwarn = (warning, warn) => {
   warn(warning)
 }
 
-export {libStylePlugin, onwarn}
+export { libStylePlugin, onwarn }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import {PluginImpl, RollupWarning} from "rollup"
+import { PluginImpl, RollupWarning } from "rollup"
 
 declare interface ProcessArgs {
   code: string
@@ -20,10 +20,11 @@ declare interface Options {
   classNamePrefix?: string
   scopedName?: string
   customPath?: string
+  customCSSPath?: (id: string) => string
 }
 
 declare const onwarn: (warning: RollupWarning, defaultHandler: (warning: string | RollupWarning) => void) => void
 
 declare const libStylePlugin: PluginImpl<Options>
 
-export {onwarn, libStylePlugin}
+export { onwarn, libStylePlugin }


### PR DESCRIPTION
Add a callback that allows you to transform where to store import the generated CSS file from. For example, `Header.module.scss` transformed to `Header.module.css`, but NextJS treat `.module.scss` as CSS module, so you cannot import it directly. Then you can use `return id.replace(process.cwd(), "").replace(/\\/g, "/").replace('.module', '')` to fix it. This will affect both CSS filename and the `import` statement.