### PR TITLE
feat: Add customCSSInjectedPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Type: (id: string) => string<br />
 Default: undefined<br />
 Description: A callback that allows you to transform where to store import the generated CSS file from. For example, `Header.module.scss` transformed to `Header.module.css`, but NextJS treat `.module.scss` as CSS module, so you cannot import it directly. Then you can use `return id.replace(process.cwd(), "").replace(/\\/g, "/").replace('.module', '')` to fix it. This will affect both CSS filename and the `import` statement.
 
+### customCSSInjectedPath
+Type: (id: string) => string<br />
+Default: undefined<br />
+Description: A callback that allows you to transform the injected `import` statement path. For example, if you have deep nested css files like `./components/headers/Header.css` placed along with their corresponding js, this can be transformed to `./Header.css`. This will affect both CSS filename and the `import` statement.
 
 ## Global Styles
 In some cases, we will want to create global class names (without hash)

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ const defaultLoaders = [
 const replaceMagicPath = (fileContent, customPath = ".") => fileContent.replace(MAGIC_PATH_REGEX, customPath)
 
 const libStylePlugin = (options = {}) => {
-  const {customPath, customCSSPath, loaders, include, exclude, importCSS = true, ...postCssOptions} = options
+  const {customPath, customCSSPath, customCSSInjectedPath, loaders, include, exclude, importCSS = true, ...postCssOptions} = options
   const allLoaders = [...(loaders || []), ...defaultLoaders]
   const filter = createFilter(include, exclude)
   const getLoader = (filepath) => allLoaders.find((loader) => loader.regex.test(filepath))
@@ -58,6 +58,7 @@ const libStylePlugin = (options = {}) => {
       }
 
       const cssFilePath = customCSSPath ? customCSSPath(id) : getFilePath()
+      const cssFileInjectedPath = customCSSInjectedPath ? customCSSInjectedPath(cssFilePath) : cssFilePath
 
       // create a new css file with the generated hash class names
       this.emitFile({
@@ -66,7 +67,7 @@ const libStylePlugin = (options = {}) => {
         source: postCssResult.extracted.code,
       })
 
-      const importStr = importCSS ? `import "${MAGIC_PATH}${cssFilePath.replace(loader.regex, ".css")}";\n` : ""
+      const importStr = importCSS ? `import "${MAGIC_PATH}${cssFileInjectedPath.replace(loader.regex, ".css")}";\n` : ""
 
       // create a new js file with css module
       return {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,7 @@ declare interface Options {
   scopedName?: string
   customPath?: string
   customCSSPath?: (id: string) => string
+  customCSSInjectedPath?: (id: string) => string
 }
 
 declare const onwarn: (warning: RollupWarning, defaultHandler: (warning: string | RollupWarning) => void) => void


### PR DESCRIPTION
You can use `customCSSInjectedPath` if your injected css import path is different from the path that your css file is placed.
